### PR TITLE
Add wsl support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src/syntax.grm.sig
 src/syntax.grm.sml
 test/should_run/*.lua
 test/mlbasis/should_run/*.lua
+lunarml

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ A Standard ML compiler that produces Lua.
 
 ## Building
 
-You need MLton to build the executable, and Lua 5.3+ to run the compiled script.
+You need a recent version of MLton to build the executable, and Lua 5.3+ to run the compiled script.
+If running `make` yields the error "Undefined variable USyntax.VIdSet.disjoint", you need to update
+your version of MLton (tested with `MLton 20130715`).
 
 ```
 $ make


### PR DESCRIPTION
Hi,

first of all **thanks** for working on LunarML - ML and Lua will be a great combination!

When trying to get LunarML running on WSL (with Ubuntu 20.04) I encountered two issues:

1. Building the executable didn't work ("Undefined variable USyntax.VIdSet.disjoint"), which was caused by an outdated version of MLton being available via `apt` on Ubuntu 20.04. Installing an up-to-date binary (`MLton 20130715`) did help. I added that bit of information to the Readme file.
2. Running tests showed errors, caused by different line endings for Unix and Windows when working with WSL. I added the Lua function `split_join_lines()` to `test/run.lua` to unify line endings to `\n` and that worked.

Hope the changes are OK for you.

Thanks again, Frank
